### PR TITLE
docs: remove outdated project bootstrapping info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
-
 ## Getting Started
 
 First, run the development server:


### PR DESCRIPTION
The project bootstrapping information is no longer relevant as the project has evolved. This change keeps the README concise and up-to-date.